### PR TITLE
Reorder suggestions, make draper happy <3

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Made a service that uses Red-Index as a source? [Make a PR](https://github.com/C
 Yes! This is exactly the point of this project. Fetch the [minified version](https://raw.githubusercontent.com/Cog-Creators/Red-Index/master/index/1-min.json) from whatever website / service you're building and parse it. In case of substantial changes to the data format we'll increase the version number and the link will change.
 
 ### Can I add my repo to the list?
-Yes! You can create a [Cog Creator application](https://cogboard.red/c/apps/12) to become a Cog Creator and have your repo added to the approved list (along with a few other perks). If you're still waiting for your application to be reviewed or you're not quite ready to apply, you can [make a PR](https://github.com/Cog-Creators/Red-Index/pulls) to have your repo potentially added to the unapproved list.
+Yes! You can create a [Cog Creator application](https://cogboard.red/c/apps/12) to become a Cog Creator and have your repo added to the approved category (along with a few other perks). If you're still waiting for your application to be reviewed or you're not quite ready to apply, you can [make a PR](https://github.com/Cog-Creators/Red-Index/pulls) to have your repo potentially added to the unapproved category.
 
 ### How does this work?
 [Github Actions](https://github.com/features/actions) are what makes this possible. Every 15 minutes, or on manual trigger, the workflow takes care of parsing the repositories list, cloning each one of them and compiling a [JSON file](https://github.com/Cog-Creators/Red-Index/tree/master/index) with all the current metadata of each repository and repo.

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Made a service that uses Red-Index as a source? [Make a PR](https://github.com/C
 Yes! This is exactly the point of this project. Fetch the [minified version](https://raw.githubusercontent.com/Cog-Creators/Red-Index/master/index/1-min.json) from whatever website / service you're building and parse it. In case of substantial changes to the data format we'll increase the version number and the link will change.
 
 ### Can I add my repo to the list?
-Yes! [Make a PR](https://github.com/Cog-Creators/Red-Index/pulls) and your repo will be added to the unapproved category of the list. If you want to be in the approved category, [apply here](https://cogboard.red/c/apps/12)
+Yes! You can create a [Cog Creator application](https://cogboard.red/c/apps/12) to become a Cog Creator and have your repo added to the approved list (along with a few other perks). If you're still waiting for your application to be reviewed or you're not quite ready to apply, you can [make a PR](https://github.com/Cog-Creators/Red-Index/pulls) to have your repo potentially added to the unapproved list.
 
 ### How does this work?
 [Github Actions](https://github.com/features/actions) are what makes this possible. Every 15 minutes, or on manual trigger, the workflow takes care of parsing the repositories list, cloning each one of them and compiling a [JSON file](https://github.com/Cog-Creators/Red-Index/tree/master/index) with all the current metadata of each repository and repo.


### PR DESCRIPTION
Reorders the suggestions for getting added to the list to add emphasis to CC apps over unapproved repos, makes it less certain that a repo will be added to the unapproved list.