### PR TITLE
Add vex-cogs to unapproved list

### DIFF
--- a/repositories.yaml
+++ b/repositories.yaml
@@ -57,6 +57,7 @@ unapproved:
   - https://github.com/npc203/npc-cogs
   - https://github.com/kreusada/Kreusada-Cogs
   - https://github.com/Obi-Wan3/OB13-Cogs
+  - https://github.com/Vexed01/Vex-Cogs
 
 # List of flagged cogs
 # Cogs present in this list will be ignored by the indexer


### PR DESCRIPTION
Add https://github.com/Vexed01/Vex-Cogs to the list of unapproved repos