### PR TITLE
Add owo-cogs to unapproved list

### DIFF
--- a/repositories.yaml
+++ b/repositories.yaml
@@ -60,6 +60,7 @@ unapproved:
   - https://github.com/Vexed01/Vex-Cogs
   - https://github.com/Just-Jojo/JojoCogs
   - https://github.com/thedataleek/eris-cogs
+  - https://github.com/siu3334/owo-cogs
 
 # List of flagged cogs
 # Cogs present in this list will be ignored by the indexer


### PR DESCRIPTION
Please add https://github.com/siu3334/owo-cogs to the list of unapproved repos. Thank you. 