### PR TITLE
Use shallow clone for clone of Red-Index as well

### DIFF
--- a/.github/workflows/run-indexer.yml
+++ b/.github/workflows/run-indexer.yml
@@ -15,7 +15,6 @@ jobs:
     steps:
     - uses: actions/checkout@v2
       with:
-        fetch-depth: 0
         persist-credentials: false
     - name: Set up Python 3.8
       uses: actions/setup-python@v2


### PR DESCRIPTION
I missed that in the previous PR and this should be unneeded as we do the same on Red's main repo:
https://github.com/Cog-Creators/Red-DiscordBot/blob/01561fbe07dc3783d87142b030370eeb2561c26e/.github/workflows/prepare_release.yml#L19