### PR TITLE
Remove Predeactor-Cogs from approved repos

### DIFF
--- a/repositories.yaml
+++ b/repositories.yaml
@@ -39,7 +39,6 @@ approved:
   - https://gitlab.com/CrunchBangDev/cbd-cogs
   - https://github.com/grayconcaves/FanCogs
   - https://github.com/flapjax/FlapJack-Cogs
-  - https://github.com/Predeactor/Predeactor-Cogs
   - https://github.com/phenom4n4n/phen-cogs
   - https://github.com/SharkyTheKing/Sharky
   - https://github.com/Twentysix26/x26-Cogs


### PR DESCRIPTION
As said in #cog-creators in the Red - Cog Support channel, I want to be done forever with my cogs and I accept to lose my [Cog Creator's privileges respecting the policy 10](https://github.com/Cog-Creators/Red-Policies/blob/master/policies/active/0010.md#breakdown).
You're gently asked to not add it into the unapproved list. Thank you.
