### PR TITLE
Add lui-cogs-v3 to unapproved list

### DIFF
--- a/repositories.yaml
+++ b/repositories.yaml
@@ -64,6 +64,7 @@ unapproved:
   - https://github.com/Onii-Chan-Discord/onii-cogs
   - https://github.com/OofChair/OofCogs
   - https://github.com/vertyco/vrt-cogs
+  - https://github.com/Injabie3/lui-cogs-v3
 
 # List of flagged cogs
 # Cogs present in this list will be ignored by the indexer


### PR DESCRIPTION
This PR adds lui-cogs-v3 to the unapproved list.

I think I'm still missing some keys in the per-cog info.json files, will continue to sort those out.