### PR TITLE
Add goonstation/gooncogs to the unapproved list

### DIFF
--- a/repositories.yaml
+++ b/repositories.yaml
@@ -65,6 +65,7 @@ unapproved:
   - https://github.com/OofChair/OofCogs
   - https://github.com/vertyco/vrt-cogs
   - https://github.com/Injabie3/lui-cogs-v3
+  - https://github.com/goonstation/gooncogs
 
 # List of flagged cogs
 # Cogs present in this list will be ignored by the indexer


### PR DESCRIPTION
Cleaning up and improving the cogs is still on my miles long todo list so unapproved for now.