### PR TITLE
Add FlameBountyCogs to the unapproved section

### DIFF
--- a/repositories.yaml
+++ b/repositories.yaml
@@ -80,6 +80,7 @@ unapproved:
   - https://github.com/Noa-DiscordBot/noa-cogs
   - https://github.com/nukdokplex/nukdokplex-cogs
   - https://github.com/Church13/YeahCogs
+  - https://github.com/Flame442/FlameBountyCogs
 
 # List of flagged cogs
 # Cogs present in this list will be ignored by the indexer


### PR DESCRIPTION
I didn't do this earlier, because the cogs in this repo are there because they are fairly niche compared to my main repo, but enough people have wanted some of this kind of functionality that I might as well let them appear on the index :P