### PR TITLE
Remove tpun from unapproved list as it no longer exists

### DIFF
--- a/repositories.yaml
+++ b/repositories.yaml
@@ -81,7 +81,6 @@ unapproved:
   - https://github.com/nukdokplex/nukdokplex-cogs
   - https://github.com/Church13/YeahCogs
   - https://github.com/Flame442/FlameBountyCogs
-  - https://github.com/batman202012/tpun
   - https://github.com/jmesfo0/jmes-cogs
   - https://github.com/Mister-42/mr42-cogs
   - https://github.com/orchidalloy/crab-cogs


### PR DESCRIPTION
The repo has not existed for 2 months, see: https://github.com/Cog-Creators/Red-Index/commit/36b2a0023e6036127bcf524b3ee4a8dcbdc19717