### PR TITLE
Add T14D3-Cogs to unapproved repositories

### DIFF
--- a/repositories.yaml
+++ b/repositories.yaml
@@ -83,6 +83,7 @@ unapproved:
   - https://github.com/flaree/pokecord-red
   - https://github.com/taintedvalor/Valors-cogs
   - https://github.com/fakesmile9704/fake-cogs
+  - https://github.com/T14D3/T14D3-Cogs
   
 # List of flagged cogs
 # Cogs present in this list will be ignored by the indexer


### PR DESCRIPTION
Just leaving my 2 cents here, at the moment it only contains my Brainfuck-Cog, but will definitely add more in the near future