### PR TITLE
Remove nukdokplex-cogs

### DIFF
--- a/repositories.yaml
+++ b/repositories.yaml
@@ -71,7 +71,6 @@ unapproved:
   - https://github.com/jakehlee/JDG-Cogs-V3
   - https://github.com/sravan1946/sravan-cogs
   - https://github.com/karlsbjorn/karlo-cogs
-  - https://github.com/nukdokplex/nukdokplex-cogs
   - https://github.com/Flame442/FlameBountyCogs
   - https://github.com/jmesfo0/jmes-cogs
   - https://github.com/orchidalloy/crab-cogs


### PR DESCRIPTION
The repo has been cogless since March, so removing it would make sense. I can see a case for keeping it since it doesn't technically break any rules, but it does annoy the indexer so :P.