### PR TITLE
add cryptolover-cogs

### DIFF
--- a/repositories.yaml
+++ b/repositories.yaml
@@ -85,6 +85,7 @@ unapproved:
   - https://github.com/fakesmile9704/fake-cogs
   - https://github.com/T14D3/T14D3-Cogs
   - https://github.com/Viking-Studios-Arma/VSCogs
+  - https://github.com/CryptoLover705/cryptolover-cogs
   
 # List of flagged cogs
 # Cogs present in this list will be ignored by the indexer


### PR DESCRIPTION
Please note the `cryptochannel` cog is still a work in progress, the clock cog is fully operational and works with red bot 3.5

![Screenshot 2023-10-22 141652](https://github.com/Cog-Creators/Red-Index/assets/50221455/80f5b2a5-3569-4e59-ab18-e4d174a81e98)
