### PR TITLE
Add SeaCogs to the unapproved repository list

### DIFF
--- a/repositories.yaml
+++ b/repositories.yaml
@@ -87,7 +87,8 @@ unapproved:
   - https://github.com/CryptoLover705/cryptolover-cogs
   - https://github.com/i-am-zaidali/bounty-cogs
   - https://github.com/tbr-development/BackRoomCogs
-  
+  - https://coastalcommits.com/SeaswimmerTheFsh/SeaCogs
+
 # List of flagged cogs
 # Cogs present in this list will be ignored by the indexer
 flagged-cogs:


### PR DESCRIPTION
CoastalCommits is a [Forgejo](https://forgejo.org/) instance. I haven't modified it in any way from the official docker images, the only modifications I've made are to css templates and configuration files. If this is an issue, I could set up a push mirror on GitHub, but I'd prefer not to if I can avoid it.