### PR TITLE
Remove flag from updated repos

### DIFF
--- a/repositories.yaml
+++ b/repositories.yaml
@@ -105,15 +105,6 @@ flagged-cogs:
     - roleplay
     - wikia
     - xkcd
-  https://github.com/nmbook/FalcomBot-cogs/:
-    - autoban
-    - hiback
-    - randt
-    - rolereqs
-    - rot13
-    - textt
-    - topic
-    - wikia
   https://github.com/Redjumpman/Jumper-Plugins/:
     - casino
     - coupon
@@ -124,10 +115,6 @@ flagged-cogs:
     - raffle
     - russianroulette
     - shop
-  https://github.com/dualmoon/Cogs.v3:
-    - feedback
-    - selfassign
-    - weeedcog
   https://gitlab.com/Eragon5779/TechCogsV3:
     - cpucompare
     - encode


### PR DESCRIPTION
[FalcomBog-Cogs](https://github.com/nmbook/FalcomBot-cogs/commit/a32c8a2a55a2bb6d204749371ef450df591f8e2f) and [Cogs.v3](https://github.com/dualmoon/Cogs.v3/commit/90d2a56c820a51d270344eac9db523089f42cf47) have received updates which make them load on 3.5. They have been removed from the list of flagged cogs.