### PR TITLE
Add wizard cogs to unapproved list

### DIFF
--- a/repositories.yaml
+++ b/repositories.yaml
@@ -88,6 +88,7 @@ unapproved:
   - https://github.com/i-am-zaidali/bounty-cogs
   - https://github.com/tbr-development/BackRoomCogs
   - https://coastalcommits.com/SeaswimmerTheFsh/SeaCogs
+  - https://github.com/space-wizards/wizard-cogs
 
 # List of flagged cogs
 # Cogs present in this list will be ignored by the indexer


### PR DESCRIPTION
https://github.com/space-wizards/wizard-cogs

We are *probably* gonna be getting approved as well at some point. But for now, I feel like this is good too.

Right now only 2 of our cogs are gonna go out in the wild on the index and are the most useful ones. "Autoresponder" is an internal meme and another a pretty normal echo command. They are both marked as hidden in their json.

From what I understood when I asked on the redbot discord server, since I'm an org member (of wizard cog's organization) I'm allowed to add us here.