### PR TITLE
add ben-cogs to unapproved 

### DIFF
--- a/repositories.yaml
+++ b/repositories.yaml
@@ -92,6 +92,7 @@ unapproved:
   - https://git.purplepanda.cc/blizz/blizz-cogs
   - https://github.com/Bartixxx32/BartixxxCogs
   - https://github.com/ChaseCares/CCCogs
+  - https://github.com/BenCos17/ben-cogs
 
 # List of flagged cogs
 # Cogs present in this list will be ignored by the indexer


### PR DESCRIPTION
add my cog repo to the unapproved section of the index 
(feedback is always welcome just to add)
