### PR TITLE
change my repository (SeaswimmerTheFsh/SeaCogs) to the updated url (Sea/Cogs)

### DIFF
--- a/repositories.yaml
+++ b/repositories.yaml
@@ -87,7 +87,7 @@ unapproved:
   - https://github.com/CryptoLover705/cryptolover-cogs
   - https://github.com/i-am-zaidali/bounty-cogs
   - https://github.com/shitshowdevelopment/ShitShowCogs
-  - https://coastalcommits.com/SeaswimmerTheFsh/SeaCogs
+  - https://coastalcommits.com/Sea/Cogs
   - https://github.com/space-wizards/wizard-cogs
   - https://git.purplepanda.cc/blizz/blizz-cogs
   - https://github.com/Bartixxx32/BartixxxCogs


### PR DESCRIPTION
recently changed my username on coastalcommits, just ensuring that the repo name isn't stolen without me noticing