### PR TITLE
Allow Cog Creators to override the repository name present in Index installation commands

### DIFF
--- a/indexer.py
+++ b/indexer.py
@@ -89,6 +89,7 @@ class Repo:
             self._error = "Error reading repo info.json. Possibly invalid."
             return
 
+        self.name = info.get("name", self.name)
         self.author = info.get("author", [])
         self.description = info.get("description", "")
         self.short = info.get("short", "")


### PR DESCRIPTION
This PR allows for Cog Creator to specify the `name` key in their repository's `info.json` file, to override the name retrieved from the repository's URL. This changes the repository install command listed underneath cog descriptions on the Index.
For example, the repository install command for `https://coastalcommits.com/Sea/Cogs` on the Index would change from:
`repo add cogs https://coastalcommits.com/Sea/Cogs` to `repo add SeaCogs https://coastalcommits.com/Sea/Cogs`.

I've compiled a list of repositories that would be affected by this change below *(small changes like capitalization differences or a missing/present `-` won't be listed here)*:
- [`discord_cogs` -> `Malarne - discord_cogs`](https://github.com/Malarne/discord_cogs)
- [`mr42-cogs` -> `Mr42`](https://github.com/Mister-42/mr42-cogs)
- [`Toxic-Cogs` -> `Toxic Cogs`](https://github.com/NeuroAssassin/Toxic-Cogs)
- [`predacogs` -> `Predä Cogs`](https://github.com/PredaaA/predacogs)
- [`Jumper-Plugins` -> `JumperCogs`](https://github.com/Redjumpman/Jumper-Plugins)
- [`Flare-Cogs` -> `Flare's Cogs`](https://github.com/flaree/Flare-Cogs)
- [`Flapjack-Cogs` -> `FlapJack Cogs`](https://github.com/flapjax/FlapJack-Cogs)
- [`pokecord-red` -> `Pokecord`](https://github.com/flaree/pokecord-red)
- [`bounty-cogs` -> `cray-cogs.`](https://github.com/i-am-zaidali/bounty-cogs)
- [`cray-cogs` -> `cray-cogs.`](https://github.com/i-am-zaidali/cray-cogs)
- [`kennnyshiwa-cogs` -> `Kennnyshiwa's Cogs`](https://github.com/kennnyshiwa/kennnyshiwa-cogs)
- [`FalcomBot-cogs` -> `Falcogs`](https://github.com/nmbook/FalcomBot-cogs)
- [`palmtree5-cogs` -> `palmtree5's cogs`](https://github.com/palmtree5/palmtree5-cogs)
- [`phen-cogs` -> `Phen-Cogs.`](https://github.com/phenom4n4n/phen-cogs)
- [`wizard-cogs` -> `Space Wizards Cogs`](https://github.com/space-wizards/wizard-cogs)
- [`tmerc-cogs` -> `tmerc cogs`](https://github.com/tmercswims/tmerc-cogs)