### PR TITLE
added Chovin/Dumb-Cogs to unapproved

### DIFF
--- a/repositories.yaml
+++ b/repositories.yaml
@@ -98,6 +98,7 @@ unapproved:
   - https://codeberg.org/jakjakob/jak-cogs
   - https://github.com/willamettefour/willamette-cogs
   - https://github.com/Coltuna/unknown-cogs
+  - https://github.com/Chovin/Dumb-Cogs
 
 # List of flagged cogs
 # Cogs present in this list will be ignored by the indexer


### PR DESCRIPTION
currently only has PICO-8 and Invasion cogs