### PR TITLE
Add spideysimp-cogs to unapproved

### DIFF
--- a/repositories.yaml
+++ b/repositories.yaml
@@ -99,6 +99,7 @@ unapproved:
   - https://github.com/willamettefour/willamette-cogs
   - https://github.com/Coltuna/unknown-cogs
   - https://github.com/Chovin/Dumb-Cogs
+  - https://github.com/spidey-simp/spideysimp-cogs
 
 # List of flagged cogs
 # Cogs present in this list will be ignored by the indexer


### PR DESCRIPTION
Added the github link to spideysimp-cogs to the unapproved list