### PR TITLE
Add vti-cogs to unapproved section

### DIFF
--- a/repositories.yaml
+++ b/repositories.yaml
@@ -100,6 +100,7 @@ unapproved:
   - https://github.com/Coltuna/unknown-cogs
   - https://github.com/Chovin/Dumb-Cogs
   - https://github.com/spidey-simp/spideysimp-cogs
+  - https://github.com/joaovti/vti-cogs
 
 # List of flagged cogs
 # Cogs present in this list will be ignored by the indexer


### PR DESCRIPTION
Request to add my repository to the unapproved section 