### PR TITLE
Rename RedBot-Cogs to Reediculous-Cogs

### DIFF
--- a/repositories.yaml
+++ b/repositories.yaml
@@ -61,7 +61,7 @@ approved:
   - https://github.com/zhaobenny/bz-cogs
   - https://github.com/sravan1946/sravan-cogs
   - https://github.com/Grommish/Grommish-Cogs
-  - https://github.com/reediculous456/RedBot-Cogs
+  - https://github.com/reediculous456/Reediculous-Cogs
 
 # List of unapproved repos.
 # Will be parsed and categorized as "unapproved" by the indexer


### PR DESCRIPTION
Discussed with the Cog Creator. Name change so that the repo name shown in the URL is more of a descriptor of the Cog Creator than "RedBot-Cogs".