### PR TITLE
Remove ShitShowCogs from unapproved

### DIFF
--- a/repositories.yaml
+++ b/repositories.yaml
@@ -88,7 +88,6 @@ unapproved:
   - https://github.com/Viking-Studios-Arma/VSCogs
   - https://github.com/CryptoLover705/cryptolover-cogs
   - https://github.com/i-am-zaidali/bounty-cogs
-  - https://github.com/shitshowdevelopment/ShitShowCogs
   - https://coastalcommits.com/Sea/Cogs
   - https://github.com/space-wizards/wizard-cogs
   - https://git.purplepanda.cc/blizz/blizz-cogs


### PR DESCRIPTION
Repo and associated account are a 404.