### PR TITLE
Delist slashtags from phen-cogs

### DIFF
--- a/repositories.yaml
+++ b/repositories.yaml
@@ -260,3 +260,5 @@ flagged-cogs:
     - temprole
     - translate
     - uploadstreaks
+  https://github.com/phenom4n4n/phen-cogs:
+    - slashtags


### PR DESCRIPTION
The repo is archived and the `TagScript` version the cog is locked to appears to not support dpy 2.0. The cog does not appear to function at all in this state, and having it listed only adds confusion with a working albeit unapproved version fork showing up at the same time.