### PR TITLE
Allow custom display names for the repos

### DIFF
--- a/indexer.py
+++ b/indexer.py
@@ -28,7 +28,7 @@ class CustomEncoder(json.JSONEncoder):
             return json.JSONEncoder.default(self, obj)
 
 class Repo:
-    def __init__(self, metadata, category: str):
+    def __init__(self, metadata, category: str, *, name=""):
         """Anything exposed here will be serialized later
 
         Attributes starting with rx_ deviate from the info.json spec
@@ -43,7 +43,8 @@ class Repo:
         self.short = ""
         self._metadata = metadata
         self._url = metadata.url
-        self.name = ""
+        self._url_name = ""
+        self.name = name
         self.rx_branch = ""
         self.rx_added_at = ""
         self.rx_approved_at = ""
@@ -67,15 +68,17 @@ class Repo:
         if url.endswith("/"):
             url = url[:-1]
 
-        self.name = name
+        if not self.name:
+            self.name = name
         self.rx_branch = branch
         self._url = url
+        self._url_name = name
 
     def folder_check_and_get_info(self):
         if self._error:
             return
 
-        safe_name = re.sub(r"[^a-zA-Z0-9_\-\.]", "", self.name).strip(".")
+        safe_name = re.sub(r"[^a-zA-Z0-9_\-\.]", "", self._url_name).strip(".")
         prefix = f"{safe_name}_" if safe_name else ""
         base_path = CACHE / Path(f"{prefix}{sha1_digest(self._url)}")
         if not base_path.is_dir():
@@ -379,14 +382,19 @@ def main():
     repos = []
 
     for k in ("approved", "unapproved"):
-        if data[k]: # Can be None if empty
-            for url in data[k]:
-                if url in metadata:
-                    repo_metadata = metadata[url]
-                else:
-                    repo_metadata = InternalRepoMetadata(url)
-                    metadata[url] = repo_metadata
-                repos.append(Repo(repo_metadata, k))
+        if not data[k]: # Can be None if empty
+            continue
+        for repo_info in data[k]:
+            if isinstance(repo_info, str):
+                repo_info = {"url": repo_info}
+            url = repo_info["url"]
+            if url in metadata:
+                repo_metadata = metadata[url]
+            else:
+                repo_metadata = InternalRepoMetadata(url)
+                metadata[url] = repo_metadata
+            name = repo_info.get("name", "")
+            repos.append(Repo(repo_metadata, k, name=name))
 
     for r in repos:
         r.folder_check_and_get_info()

--- a/parser.py
+++ b/parser.py
@@ -1,3 +1,4 @@
+import itertools
 import os
 import re
 import sys
@@ -41,10 +42,11 @@ if __name__ == "__main__":
 
     repos = []
 
-    if data["approved"]:
-        repos.extend(data["approved"])
-    if data["unapproved"]:
-        repos.extend(data["unapproved"])
+    for repo_info in itertools.chain(data["approved"] or (), data["unapproved"] or ()):
+        if isinstance(repo_info, str):
+            repos.append(repo_info)
+        else:
+            repos.append(repo_info["url"])
 
     for r in repos:
         name = get_name(r)

--- a/repositories-example.yaml
+++ b/repositories-example.yaml
@@ -7,15 +7,26 @@
 # List of approved repos
 # Will be parsed and categorized as "approved" by the indexer
 approved:
-  - https://github.com/User1/RepoName
-  - https://github.com/User2/RepoName@branchname
-  - https://github.com/User3/RepoName
+  # Long form allowing to specify the name to put in the `name` key of the repo
+  - url: https://github.com/User1/RepoName
+    name: user1-repo-name
+  - url: https://github.com/User2/RepoName@branchname
+    name: user2-repo-name
+  # Short form that will automatically use `RepoName` as the `name` key of the repo
+  - https://github.com/User3/User3RepoName
+  - https://github.com/User4/User4RepoName@branchname
 
 # List of unapproved repos.
 # Will be parsed and categorized as "unapproved" by the indexer
 unapproved:
-  - https://github.com/User4/RepoName@branchname
-  - https://gitlab.com/User5/RepoName
+  # Long form allowing to specify the name to put in the `name` key of the repo
+  - url: https://github.com/User5/RepoName
+    name: user5-repo-name
+  - url: https://github.com/User6/RepoName@branchname
+    name: user6-repo-name
+  # Short form that will automatically use `RepoName` as the `name` key of the repo
+  - https://github.com/User3/User7RepoName
+  - https://github.com/User4/User8RepoName@branchname
 
 # List of flagged cogs
 # Cogs present in this list will be ignored by the indexer.
@@ -23,7 +34,7 @@ flagged-cogs:
   https://gitlab.com/User5/RepoName:   # <- Mind the colon!
     - cogname1
     - cogname2
-  https://github.com/User3/RepoName:
+  https://github.com/User2/RepoName:
     - cogname1
   https://github.com/User1/RepoName:
     - cogname8


### PR DESCRIPTION
Some of the repos added to the index don't have particularly descriptive names in their URLs. This PR will allow a different name than URL's to be set as the name of the repo.

From approved repos, I'd consider these too generic:
```
Cogs.v3 (https://github.com/dualmoon/Cogs.v3)
discord_cogs (https://github.com/Malarne/discord_cogs)
```
From unapproved repos, I'd consider these too generic:
```
bounty-cogs (https://github.com/i-am-zaidali/bounty-cogs)
cogs (https://github.com/psykzz/cogs)
RedCogs (https://github.com/CatalystND/RedCogs)
cogs-cogs (https://github.com/Cognitohazard/cogs-cogs)
```