### PR TITLE
Add livetennisapi/livetennis-redbot to unapproved list

### DIFF
--- a/repositories.yaml
+++ b/repositories.yaml
@@ -120,6 +120,7 @@ unapproved:
     name: catalystnd-cogs
   - url: https://github.com/Cognitohazard/cogs-cogs
     name: cognitohazard-cogs
+  - https://github.com/livetennisapi/livetennis-redbot
 
 # List of flagged cogs
 # Cogs present in this list will be ignored by the indexer


### PR DESCRIPTION
## Summary
- Adds [livetennisapi/livetennis-redbot](https://github.com/livetennisapi/livetennis-redbot) to the unapproved repositories list.

## Cogs included
- **LiveTennis** — Live ATP/WTA/Challenger/ITF/Juniors tennis scores from livetennisapi.com: live matches with per-set scores and serving indicator, upcoming matches, results, single-match detail and player search. Query-driven (no background polling loops); responses cached for 60s to respect the API's free-tier rate limits.

## Repository structure
- Root `info.json` and per-cog `info.json` present
- LICENSE (MIT)
- README with installation and usage documentation
- `min_bot_version`: 3.5.0
- `end_user_data_statement` included; no end user data stored

🤖 Generated with [Claude Code](https://claude.com/claude-code)